### PR TITLE
fix(rate-limit): enable trust proxy to correctly identify client IPs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -47,7 +47,7 @@ const swaggerOptions = {
 };
 
 const swaggerDocs = swaggerJsDoc(swaggerOptions);
-
+app.use("trust proxy", 1);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION

- Express não confiava no cabeçalho `X-Forwarded-For` por padrão, usando apenas o IP do proxy
- Isso fazia o express-rate-limit considerar todos os usuários como o mesmo IP
- Ativado `app.set("trust proxy", 1)` para confiar no primeiro proxy e usar o IP real do cliente